### PR TITLE
Update pickerview.cpp

### DIFF
--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -986,6 +986,10 @@ class PickerMarker : public RecordMarker {
 			if ( !_referencedPick->filterID().empty() )
 				text += QString("\nfilter: %1").arg(_referencedPick->filterID().c_str());
 			try {
+				double confidence = _referencedPick->time().confidenceLevel();
+				text += QString("\nconfidence: %1").arg(confidence);
+			}
+			catch ( ... ) {}
 				double baz = _referencedPick->backazimuth().value();
 				text += QString("\nbackazimuth: %1°").arg(baz);
 			}


### PR DESCRIPTION
This allows the [pick time confidence level](https://www.seiscomp.de/doc/base/api-python.html#seiscomp.datamodel.TimeQuantity.confidenceLevel) to be shown in the tooltip of the picker window in `scolv`. It is useful with automatic pickers providing confidence level, e.g., based on machine learning.